### PR TITLE
Added WCS support

### DIFF
--- a/nirdust.py
+++ b/nirdust.py
@@ -205,15 +205,6 @@ class NirdustSpectrum:
     spectrum_length: int
         The number of items in the spectrum axis as in len() method.
 
-    dispersion_key: float
-        Header keyword containing the dispersion in Å/pix.
-
-    first_wavelength: float
-        Header keyword containing the wavelength of first pixel.
-
-    dispersion_type: str
-        Header keyword containing the type of the dispersion function.
-
     spec1d: specutils.Spectrum1D object
         Containis the wavelength axis and the flux axis of the spectrum in
         unities of Å and ADU respectively.
@@ -448,14 +439,13 @@ class NirdustResults:
 
 def _get_science_extension(hdulist, extension):
     """Auto detect fits science extension using the provided keywords."""
-
     if extension is not None:
         return extension
 
     if len(hdulist) == 1:
         return 0
 
-    keys = {'CRVAL1'}   # keywords that are present in science extensions
+    keys = {"CRVAL1"}  # keywords that are present in science extensions
     extl = []
     for ext, hdu in enumerate(hdulist):
         if keys.issubset(hdu.header.keys()):
@@ -471,14 +461,17 @@ def _get_science_extension(hdulist, extension):
 
 
 def pix2wavelength(pix_arr, header, z=0):
-    """Transform pixel to wavelength assuming linear dispersion.
+    """Transform pixel to wavelength.
 
-    This transformation assumes a linear dispersion.
+    This function uses header information to perform WCS transformation.
 
     Parameters
     ----------
     pix_arr: float or `~numpy.ndarray`
         Array of pixels values.
+
+    header: FITS header
+        Header of the spectrum.
 
     z: float
         Redshift of object. Use for the scale factor 1 / (1 + z).
@@ -514,7 +507,6 @@ def spectrum(
         Return a instance of the class NirdustSpectrum with the entered
         parameters.
     """
-
     spectrum_length = len(flux)
 
     # unit should be the same as first_wavelength and dispersion_key, AA ?
@@ -547,17 +539,6 @@ def read_spectrum(file_name, extension=None, z=0, **kwargs):
         Extension of the FITS file where the spectrum is stored. If None the
         extension will be automatically identified by searching for the
         relevant header keywords. Default is None.
-
-    dispersion_key: str
-        Header keyword that gives dispersion in Å/pix. Default is 'CD1_1'
-
-    first_wavelength: str
-        Header keyword that contains the wavelength of the first pixel. Default
-        is ``CRVAL1``.
-
-    dispersion_type: str
-        Header keyword that contains the dispersion function type. Default is
-        ``CTYPE1``.
 
     z: float
         Redshift of the galaxy. Used to scale the spectral axis with the

--- a/test_nirdust.py
+++ b/test_nirdust.py
@@ -112,6 +112,24 @@ def test_read_spectrum():
     )
 
 
+def test_infer_science_extension_MEF_multiple_spectrum():
+    # fits with multiple extensions
+    file_name = TEST_PATH / "external_spectrum_200pc_N4945.fits"
+    with fits.open(file_name) as hdul:
+        data = hdul[0].data
+        header = hdul[0].header
+
+    hdu0 = fits.PrimaryHDU()
+    hdu1 = fits.ImageHDU(data=data.copy(), header=header.copy())
+    hdu2 = fits.ImageHDU(data=data.copy(), header=None)
+    hdu3 = fits.ImageHDU(data=data.copy(), header=header.copy())
+    hdul = fits.HDUList([hdu0, hdu1, hdu2, hdu3])
+
+    ext_candidates = nd.infer_fits_science_extension(hdul)
+    assert len(ext_candidates) == 2
+    np.testing.assert_array_equal(ext_candidates, np.array([1, 3]))
+
+
 def test_read_spectrum_MEF_single_spectrum():
     # fits with multiple extensions
     file_name = TEST_PATH / "external_spectrum_200pc_N4945.fits"

--- a/test_nirdust.py
+++ b/test_nirdust.py
@@ -4,6 +4,7 @@
 
 import os
 import pathlib
+from unittest.mock import patch
 
 from astropy import units as u
 from astropy.io import fits
@@ -78,7 +79,6 @@ def snth_spectrum_1000(NGC4945_continuum_rest_frame):
 
     dispersion = 3.51714285129581
     first_wave = 18940.578099674
-    dispersion_type = "LINEAR  "
 
     spectrum_length = len(real_spectrum.flux)
     spectral_axis = (
@@ -100,6 +100,59 @@ def snth_spectrum_1000(NGC4945_continuum_rest_frame):
 # ==============================================================================
 # TESTS
 # ==============================================================================
+
+
+def test_read_spectrum():
+    # read with no extension and wrong keyword
+    file_name = TEST_PATH / "external_spectrum_200pc_N4945.fits"
+    obj1 = nd.read_spectrum(file_name)
+    obj2 = nd.read_spectrum(file_name, extension=0)
+    np.testing.assert_almost_equal(
+        obj1.frequency_axis.value, obj2.frequency_axis.value, decimal=10
+    )
+
+
+def test_read_spectrum_MEF_single_spectrum():
+    # fits with multiple extensions
+    file_name = TEST_PATH / "external_spectrum_200pc_N4945.fits"
+    with fits.open(file_name) as hdul:
+        data = hdul[0].data
+        header = hdul[0].header
+
+    # only one header with relevant keywords
+    hdu0 = fits.PrimaryHDU()
+    hdu1 = fits.ImageHDU(data=None)
+    hdu2 = fits.ImageHDU(data=data.copy(), header=header.copy())
+    hdu3 = fits.ImageHDU(data=None)
+    hdul = fits.HDUList([hdu0, hdu1, hdu2, hdu3])
+
+    with patch("astropy.io.fits.open", return_value=hdul):
+        obj = nd.read_spectrum("imaginary_file.fits")
+        assert isinstance(obj, nd.NirdustSpectrum)
+
+
+def test_read_spectrum_MEF_multiple_spectrum():
+    # fits with multiple extensions
+    file_name = TEST_PATH / "external_spectrum_200pc_N4945.fits"
+    with fits.open(file_name) as hdul:
+        data = hdul[0].data
+        header = hdul[0].header
+
+    hdu0 = fits.PrimaryHDU()
+    hdu1 = fits.ImageHDU(data=data.copy(), header=header.copy())
+    hdu2 = fits.ImageHDU(data=data.copy(), header=header.copy())
+    hdu3 = fits.ImageHDU(data=data.copy(), header=header.copy())
+    hdul = fits.HDUList([hdu0, hdu1, hdu2, hdu3])
+
+    with patch("astropy.io.fits.open", return_value=hdul):
+        with pytest.raises(nd.HeaderKeywordError):
+            # Default is extension=None. this tries to detect
+            # the data extension, if there are many the error is raised
+            nd.read_spectrum("imaginary_file.fits")
+
+        # If the extension is specified it should work ok
+        obj = nd.read_spectrum("imaginary_file.fits", extension=2)
+        assert isinstance(obj, nd.NirdustSpectrum)
 
 
 def test_match(NGC4945_continuum):
@@ -360,7 +413,6 @@ def test_fit_blackbody(NGC4945_continuum_rest_frame):
 
     dispersion = 3.51714285129581
     first_wave = 18940.578099674
-    dispersion_type = "LINEAR  "
 
     spectrum_length = len(real_spectrum.flux)
     spectral_axis = (
@@ -432,10 +484,10 @@ def test_pix2wavelength():
     with fits.open(file_name) as hdul:
         header = hdul[0].header
 
-    pix_0_wav = header['CRVAL1']
-    pix_disp = header['CD1_1']
+    pix_0_wav = header["CRVAL1"]
+    pix_disp = header["CD1_1"]
 
-    pix_array = np.arange(50.)
+    pix_array = np.arange(50.0)
     z = 0.1
 
     expected = (pix_0_wav + pix_disp * pix_array) / (1 + z)


### PR DESCRIPTION
The main changes are the removal of header keyword arguments: `dispersion_key`, `first_wavelength`, `dispersion_type`. These arguments were used solely for reconstructing the spectral axis. This PR implements the use of astropy WCS methods to reconstruct the spectral axis by recognizing the header format. 

The extension is now detected automatically but if many extensions are present in a file the user can still specify the extension to use. Solves issue #36.

Those 3 arguments are removed from `read_spectrum`, `spectrum` and `NirdustSpectrum`. 